### PR TITLE
fix(sec): upgrade httplib2 to 0.19.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ docutils==0.16
 drf-extensions==0.6.0
 et-xmlfile==1.0.1
 future==0.18.2
-httplib2==0.18.1
+httplib2==0.19.0
 idna==2.10
 importlib-metadata==1.7.0
 itypes==1.2.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in httplib2 0.18.1
- [CVE-2021-21240](https://www.oscs1024.com/hd/CVE-2021-21240)


### What did I do？
Upgrade httplib2 from 0.18.1 to 0.19.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS